### PR TITLE
Add validation of odin features

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.api
 Title: Serve 'odin' Models via an API
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/api.R
+++ b/R/api.R
@@ -34,7 +34,7 @@ root <- function() {
 ##'   body data :: json(validate_request)
 model_validate <- function(data) {
   data <- jsonlite::fromJSON(data, simplifyDataFrame = FALSE)
-  odin_js_validate(data$model)
+  odin_js_validate(data$model, data$requirements)
 }
 
 
@@ -43,7 +43,7 @@ model_validate <- function(data) {
 ##'   body data :: json(compile_request)
 model_compile <- function(data, pretty = FALSE) {
   data <- jsonlite::fromJSON(data, simplifyDataFrame = FALSE)
-  result <- odin_js_validate(data$model)
+  result <- odin_js_validate(data$model, data$requirements)
   if (result$valid) {
     code <- odin_js_model(data$model)
     result$model <- scalar(prepare_code(code, pretty))

--- a/R/odin.R
+++ b/R/odin.R
@@ -6,35 +6,15 @@ odin_js_model <- function(code) {
 }
 
 
-odin_js_validate <- function(code) {
+odin_js_validate <- function(code, requirements) {
   options <- odin::odin_options(target = "js")
   result <- odin::odin_validate(code, "text", options)
-
   if (result$success) {
-    dat <- odin::odin_ir_deserialise(result$result)
-    messages <- lapply(result$messages, function(m)
-      list(message = scalar(m$msg), line = m$line))
+    result$result <- odin::odin_ir_deserialise(result$result)
+    result <- check_requirements(result, requirements)
+  }
 
-    variables <- c(names(dat$data$variable$contents),
-                   names(dat$data$output$contents))
-
-    process_user <- function(nm) {
-      x <- dat$equations[[nm]]$user
-      list(name = scalar(nm),
-           default = scalar(x$default %||% NA),
-           min = scalar(x$min %||% NA),
-           max = scalar(x$max %||% NA),
-           is_integer = scalar(x$integer %||% FALSE),
-           rank = scalar(dat$data$elements[[nm]]$rank))
-    }
-    parameters <- lapply(names(dat$user), process_user)
-
-    list(valid = scalar(TRUE),
-         metadata = list(
-           variables = variables,
-           parameters = parameters,
-           messages = messages))
-  } else {
+  if (!result$success) {
     if (inherits(result$error, "odin_error")) {
       msg <- result$error$msg
       line <- result$error$line
@@ -44,8 +24,90 @@ odin_js_validate <- function(code) {
       msg <- result$error$message
       line <- integer(0)
     }
-
-    list(valid = scalar(FALSE),
-         error = list(message = scalar(msg), line = line))
+    return(list(valid = scalar(FALSE),
+                error = list(message = scalar(msg), line = line)))
   }
+
+  dat <- result$result
+  messages <- lapply(result$messages, function(m)
+    list(message = scalar(m$msg), line = m$line))
+
+  variables <- c(names(dat$data$variable$contents),
+                 names(dat$data$output$contents))
+
+  process_user <- function(nm) {
+    x <- dat$equations[[nm]]$user
+    list(name = scalar(nm),
+         default = scalar(x$default %||% NA),
+         min = scalar(x$min %||% NA),
+         max = scalar(x$max %||% NA),
+         is_integer = scalar(x$integer %||% FALSE),
+         rank = scalar(dat$data$elements[[nm]]$rank))
+  }
+  parameters <- lapply(names(dat$user), process_user)
+
+  list(valid = scalar(TRUE),
+       metadata = list(
+         variables = variables,
+         parameters = parameters,
+         messages = messages))
+}
+
+
+check_requirements <- function(result, requirements) {
+  if (is.null(requirements)) {
+    requirements <- list(timeType = "continuous")
+  }
+
+  ## This is the error we'd get if the server has asked that we check
+  ## we provide a discrete time model, regardless of what the
+  ## user-provided code is. We can't do this yet. This error should
+  ## never be surfaced in the app unless we've deployed incompatible
+  ## versions.
+  if (requirements$timeType != "continuous") {
+    msg <- "Only continuous time models currently supported"
+    return(odin_validate_error_value(msg, integer(0)))
+  }
+
+  dat <- result$result
+
+  if (dat$features$discrete) {
+    ## Once discrete time models are supported at all, we will also need
+    ## to check that stochastic models do not use output (or
+    ## interpolation?) as this is not supported in dust, even though it
+    ## still is in odin itself.
+    msg <- "Expected a model continuous time model (using deriv, not update)"
+    vars <- names(dat$data$variable$contents)
+    line <- lapply(dat$equations, function(el) {
+      if (el$lhs %in% vars && el$name %in% dat$components$rhs)
+        el$source else NULL
+    })
+    return(odin_validate_error_value(msg, line))
+  }
+  if (dat$features$has_array) {
+    ## Later, we'll check here to find out where arrays are being used
+    ## as there are two separate problems:
+    ##
+    ## * array variables and output (difficult to plot)
+    ## * array arameters (difficult to enter)
+    ##
+    ## We'll likely support these separately later but for now it's ok
+    ## to rule both out. Once we split these we'll get better line
+    ## numbers I suspect, but this should work for now.
+    msg <- "Models that use arrays are not supported"
+    line <- lapply(dat$equations, function(el) {
+      if (el$type %in% "expression_array") el$source else NULL
+    })
+    return(odin_validate_error_value(msg, line))
+  }
+
+  result
+}
+
+
+odin_validate_error_value <- function(msg, line = integer(0)) {
+  line <- sort(unlist(line, TRUE, FALSE))
+  list(success = FALSE,
+       result = NULL,
+       error = structure(list(msg = msg, line = line), class = "odin_error"))
 }

--- a/R/odin.R
+++ b/R/odin.R
@@ -76,7 +76,7 @@ check_requirements <- function(result, requirements) {
     ## to check that stochastic models do not use output (or
     ## interpolation?) as this is not supported in dust, even though it
     ## still is in odin itself.
-    msg <- "Expected a model continuous time model (using deriv, not update)"
+    msg <- "Expected a continuous time model (using deriv, not update)"
     vars <- names(dat$data$variable$contents)
     line <- lapply(dat$equations, function(el) {
       if (el$lhs %in% vars && el$name %in% dat$components$rhs)
@@ -89,7 +89,7 @@ check_requirements <- function(result, requirements) {
     ## as there are two separate problems:
     ##
     ## * array variables and output (difficult to plot)
-    ## * array arameters (difficult to enter)
+    ## * array parameters (difficult to enter)
     ##
     ## We'll likely support these separately later but for now it's ok
     ## to rule both out. Once we split these we'll get better line

--- a/inst/schema/compile_request.json
+++ b/inst/schema/compile_request.json
@@ -2,18 +2,11 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
-        "model" : {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            ]
+        "model": {
+            "$ref": "model.json"
+        },
+        "requirements": {
+            "$ref": "requirements.json"
         }
     },
     "additionalProperties": false,

--- a/inst/schema/model.json
+++ b/inst/schema/model.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "oneOf": [
+        {
+            "type": "string"
+        },
+        {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    ]
+}

--- a/inst/schema/requirements.json
+++ b/inst/schema/requirements.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "timeType": {
+            "comment": "The time model used",
+            "type": "string",
+            "enum": ["continuous"]
+        }
+    }
+}

--- a/inst/schema/validate_request.json
+++ b/inst/schema/validate_request.json
@@ -2,18 +2,11 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
-        "model" : {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            ]
+        "model": {
+            "$ref": "model.json"
+        },
+        "requirements": {
+            "$ref": "requirements.json"
         }
     },
     "additionalProperties": false,

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -92,7 +92,7 @@ test_that("Validate rejects discrete time model", {
   expect_setequal(names(res$error), c("message", "line"))
   expect_match(
     res$error$message,
-    "Expected a model continuous time model (using deriv, not update)",
+    "Expected a continuous time model (using deriv, not update)",
     fixed = TRUE)
   expect_equal(res$error$line, 2)
 })

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -81,6 +81,40 @@ test_that("Validate rejects invalid model", {
 })
 
 
+test_that("Validate rejects discrete time model", {
+  data <- list(model = "initial(x) <- 1\nupdate(x) <- 1",
+               requirements = list(timeType = "continuous"))
+  json <- jsonlite::toJSON(data, auto_unbox = TRUE)
+
+  res <- model_validate(json)
+  expect_setequal(names(res), c("valid", "error"))
+  expect_false(res$valid)
+  expect_setequal(names(res$error), c("message", "line"))
+  expect_match(
+    res$error$message,
+    "Expected a model continuous time model (using deriv, not update)",
+    fixed = TRUE)
+  expect_equal(res$error$line, 2)
+})
+
+
+test_that("Validate won't accept discrete time model", {
+  data <- list(model = "initial(x) <- 1\nupdate(x) <- 1",
+               requirements = list(timeType = "discrete"))
+  json <- jsonlite::toJSON(data, auto_unbox = TRUE)
+
+  res <- model_validate(json)
+  expect_setequal(names(res), c("valid", "error"))
+  expect_false(res$valid)
+  expect_setequal(names(res$error), c("message", "line"))
+  expect_match(
+    res$error$message,
+    "Only continuous time models currently supported)",
+    fixed = TRUE)
+  expect_equal(res$error$line, integer(0))
+})
+
+
 test_that("Validate sensibly reports on syntax error", {
   data <- list(model = "initial(x) <- 1\nderiv(y)) <- 1")
   json <- jsonlite::toJSON(data, auto_unbox = TRUE)

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -109,7 +109,7 @@ test_that("Validate won't accept discrete time model", {
   expect_setequal(names(res$error), c("message", "line"))
   expect_match(
     res$error$message,
-    "Only continuous time models currently supported)",
+    "Only continuous time models currently supported",
     fixed = TRUE)
   expect_equal(res$error$line, integer(0))
 })

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -1,0 +1,51 @@
+test_that("can validate simple model", {
+  code <- c("initial(x) <- 1",
+            "deriv(x) <- 1")
+  res <- odin_js_validate(code, NULL)
+  expect_mapequal(
+    res,
+    list(valid = scalar(TRUE),
+         metadata = list(variables = "x",
+                         parameters = list(),
+                         messages = list())))
+})
+
+
+test_that("can check requirements make sense", {
+  code <- c("initial(x) <- 1",
+            "deriv(x) <- 1")
+  res <- odin_js_validate(code, list(timeType = "discrete"))
+  expect_mapequal(
+    res,
+    list(valid = scalar(FALSE),
+         error = list(
+           message = scalar("Only continuous time models currently supported"),
+           line = integer(0))))
+})
+
+
+test_that("can ensure models have the expected time type", {
+  code <- c("initial(x) <- 1",
+            "update(x) <- 1")
+  res <- odin_js_validate(code, list(timeType = "continuous"))
+  msg <- "Expected a model continuous time model (using deriv, not update)"
+  expect_mapequal(
+    res,
+    list(valid = scalar(FALSE),
+         error = list(
+           message = scalar(msg), line = 2)))
+})
+
+
+test_that("disable use of arrays", {
+  code <- c("initial(x[]) <- 1",
+            "deriv(x[]) <- 1",
+            "dim(x) <- 5")
+  res <- odin_js_validate(code, list(timeType = "continuous"))
+  msg <- "Models that use arrays are not supported"
+  expect_mapequal(
+    res,
+    list(valid = scalar(FALSE),
+         error = list(
+           message = scalar(msg), line = c(1, 2))))
+})

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -28,7 +28,7 @@ test_that("can ensure models have the expected time type", {
   code <- c("initial(x) <- 1",
             "update(x) <- 1")
   res <- odin_js_validate(code, list(timeType = "continuous"))
-  msg <- "Expected a model continuous time model (using deriv, not update)"
+  msg <- "Expected a continuous time model (using deriv, not update)"
   expect_mapequal(
     res,
     list(valid = scalar(FALSE),


### PR DESCRIPTION
This PR adds a check that the model will be runnable by wodin, and we'll relax this over time. It's also necessary before we consider running discrete time models as we'll need to get the front end to start telling us what it needs.

For now, it's optional to specify a time type. Once this is merged and in we'll add support in the frontend, then later make it required to specify one. It's not a big deal for a while as it's not possible to create a discrete time model anyway.