### PR TITLE
Better processing of errors

### DIFF
--- a/R/odin.R
+++ b/R/odin.R
@@ -144,7 +144,7 @@ odin_error_detail <- function(msg, line) {
 ##
 ## Naturally, this relies on lots of undocumented behaviour!
 parse_parse_error <- function(msg) {
-  re <- "^<text>:([0-9]+):[0-9]: (.*?)(\n[0-9]+:.*)*$"
+  re <- "^<text>:([0-9]+):[0-9]+: (.*?)(\n[0-9]+:.*)*$"
   line <- integer(0)
 
   if (grepl(re, msg)) {

--- a/R/odin.R
+++ b/R/odin.R
@@ -111,3 +111,16 @@ odin_validate_error_value <- function(msg, line = integer(0)) {
        result = NULL,
        error = structure(list(msg = msg, line = line), class = "odin_error"))
 }
+
+
+## Convert a vector of integers into a maximally grouped set of
+## start/end pairs
+tidy_lines <- function(lines) {
+  ## The easy case:
+  if (length(lines) == 1) {
+    return(list(c(lines, lines)))
+  }
+  lines <- sort(lines)
+  group <- cumsum(c(1, diff(lines)) != 1)
+  unname(lapply(split(lines, group), function(x) c(x[1], x[length(x)])))
+}

--- a/R/odin.R
+++ b/R/odin.R
@@ -115,25 +115,9 @@ odin_validate_error_value <- function(msg, line = integer(0)) {
 }
 
 
-## Convert a vector of integers into a maximally grouped set of
-## start/end pairs
-tidy_lines <- function(lines) {
-  if (length(lines) == 0) {
-    return(list())
-  }
-  if (length(lines) == 1) {
-    return(list(c(lines, lines)))
-  }
-  lines <- sort(lines)
-  group <- cumsum(c(1, diff(lines)) != 1)
-  unname(lapply(split(lines, group), function(x) c(x[1], x[length(x)])))
-}
-
-
 odin_error_detail <- function(msg, line) {
   list(message = scalar(msg),
-       line = line,
-       line_ranges = tidy_lines(line))
+       line = line)
 }
 
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -125,7 +125,7 @@ test_that("Validate sensibly reports on syntax error", {
   expect_setequal(names(res$error), c("message", "line"))
 
   expect_match(res$error$message, "unexpected")
-  expect_equal(res$error$line, integer(0))
+  expect_equal(res$error$line, 2)
 
   ## NOTE: not a failure
   endpoint <- odin_api_endpoint("POST", "/validate")

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -56,20 +56,6 @@ test_that("can return nice errors on parse failure", {
   expect_equal(res$valid, scalar(FALSE))
   expect_equal(res$error$message, scalar("unexpected symbol"))
   expect_equal(res$error$line, 3)
-  expect_equal(res$error$line_ranges, list(c(3, 3)))
-})
-
-
-test_that("can tidy line numbers", {
-  expect_equal(tidy_lines(integer(0)), list())
-  expect_equal(tidy_lines(1), list(c(1, 1)))
-  expect_equal(tidy_lines(10), list(c(10, 10)))
-
-  expect_equal(tidy_lines(1:4), list(c(1, 4)))
-  expect_equal(tidy_lines(c(1, 2, 3, 4, 6, 9, 10)),
-               list(c(1, 4), c(6, 6), c(9, 10)))
-  expect_equal(tidy_lines(c(1, 2, 3, 4, 6, 7, 9, 10)),
-               list(c(1, 4), c(6, 7), c(9, 10)))
 })
 
 

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -71,4 +71,7 @@ test_that("can tidy up parse errors", {
   expect_equal(f("a <- 1\nx y"),
                list(msg = "unexpected symbol",
                     line = 2))
+  expect_equal(f("R_0 <- user(1.5) a"),
+               list(msg = "unexpected symbol",
+                    line = 1))
 })

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -51,7 +51,17 @@ test_that("disable use of arrays", {
 })
 
 
+test_that("can return nice errors on parse failure", {
+  res <- odin_js_validate("y <- 1\nz <- 2\nx b\na <- 1", NULL)
+  expect_equal(res$valid, scalar(FALSE))
+  expect_equal(res$error$message, scalar("unexpected symbol"))
+  expect_equal(res$error$line, 3)
+  expect_equal(res$error$line_ranges, list(c(3, 3)))
+})
+
+
 test_that("can tidy line numbers", {
+  expect_equal(tidy_lines(integer(0)), list())
   expect_equal(tidy_lines(1), list(c(1, 1)))
   expect_equal(tidy_lines(10), list(c(10, 10)))
 
@@ -60,4 +70,19 @@ test_that("can tidy line numbers", {
                list(c(1, 4), c(6, 6), c(9, 10)))
   expect_equal(tidy_lines(c(1, 2, 3, 4, 6, 7, 9, 10)),
                list(c(1, 4), c(6, 7), c(9, 10)))
+})
+
+
+test_that("can tidy up parse errors", {
+  f <- function(code) {
+    parse_parse_error(
+      tryCatch(parse(text = code, keep.source = TRUE),
+               error = identity)$message)
+  }
+  expect_equal(f("x y"),
+               list(msg = "unexpected symbol",
+                    line = 1))
+  expect_equal(f("a <- 1\nx y"),
+               list(msg = "unexpected symbol",
+                    line = 2))
 })

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -49,3 +49,15 @@ test_that("disable use of arrays", {
          error = list(
            message = scalar(msg), line = c(1, 2))))
 })
+
+
+test_that("can tidy line numbers", {
+  expect_equal(tidy_lines(1), list(c(1, 1)))
+  expect_equal(tidy_lines(10), list(c(10, 10)))
+
+  expect_equal(tidy_lines(1:4), list(c(1, 4)))
+  expect_equal(tidy_lines(c(1, 2, 3, 4, 6, 9, 10)),
+               list(c(1, 4), c(6, 6), c(9, 10)))
+  expect_equal(tidy_lines(c(1, 2, 3, 4, 6, 7, 9, 10)),
+               list(c(1, 4), c(6, 7), c(9, 10)))
+})


### PR DESCRIPTION
This PR parses R's human-readable parse error information information into something that we can use better in the frontend (we don't want the context as it prints poorly, and we do want the line number as an integer)

In wodin, before:

![image](https://user-images.githubusercontent.com/1558093/191461431-d5316840-9c4e-45ab-a65a-3d95602f256f.png)

after:

![image](https://user-images.githubusercontent.com/1558093/191461502-717ef20e-e72c-4971-b57d-6edbbd0dd8c2.png)

(to replicate, bring up wodin and add a line that contains `a b` which will trigger a syntax error)