### PR TITLE
Allow compilation of discrete time models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Suggests:
     mockery,
     testthat (>= 3.0.0)
 Remotes:
-    mrc-ide/odin@mrc-3683,
+    mrc-ide/odin@add-discrete,
     reside-ic/porcelain
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Suggests:
     mockery,
     testthat (>= 3.0.0)
 Remotes:
-    mrc-ide/odin@add-discrete,
+    mrc-ide/odin@mrc-3683,
     reside-ic/porcelain
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: API server for odin models, using porcelain/plumber.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "porcelain::porcelain_roclet"))
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 URL: https://github.com/mrc-ide/odin.api
 BugReports: https://github.com/mrc-ide/odin.api/issues
 Imports:
@@ -17,7 +17,7 @@ Imports:
     js,
     jsonlite,
     lgr,
-    odin (>= 1.3.14),
+    odin (>= 1.3.15),
     pkgbuild,
     porcelain (>= 0.1.7)
 Suggests:
@@ -25,6 +25,6 @@ Suggests:
     mockery,
     testthat (>= 3.0.0)
 Remotes:
-    mrc-ide/odin@mrc-3182,
+    mrc-ide/odin@mrc-3683,
     reside-ic/porcelain
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Suggests:
     mockery,
     testthat (>= 3.0.0)
 Remotes:
-    mrc-ide/odin@add-discrete,
+    mrc-ide/odin@mrc-3182,
     reside-ic/porcelain
 Config/testthat/edition: 3

--- a/R/api.R
+++ b/R/api.R
@@ -54,8 +54,15 @@ model_compile <- function(data, pretty = FALSE) {
 
 ##' @porcelain GET /support/runner-ode => json
 support_runner_ode <- function() {
-  code <- odin::odin_js_bundle(NULL, include_support = TRUE)$support
+  code <- read_string(system_file("js/odin.js", "odin"))
   ## We add "odinjs;" after the code here so that a JS `eval()` around
   ## it returns the object.
+  scalar(paste0(code, "odinjs;"))
+}
+
+
+##' @porcelain GET /support/runner-discrete => json
+support_runner_discrete <- function() {
+  code <- read_string(system_file("js/dust.js", "odin"))
   scalar(paste0(code, "odinjs;"))
 }

--- a/R/odin.R
+++ b/R/odin.R
@@ -121,8 +121,7 @@ odin_error_detail <- function(msg, line) {
 }
 
 
-
-## The patterns that things might confirm to are
+## The patterns that things might conform to are
 ##
 ## (file):(line):(column): (message)
 ##

--- a/R/odin.R
+++ b/R/odin.R
@@ -57,28 +57,17 @@ odin_js_validate <- function(code, requirements) {
 
 
 check_requirements <- function(result, requirements) {
-  if (is.null(requirements)) {
-    requirements <- list(timeType = "continuous")
-  }
-
-  ## This is the error we'd get if the server has asked that we check
-  ## we provide a discrete time model, regardless of what the
-  ## user-provided code is. We can't do this yet. This error should
-  ## never be surfaced in the app unless we've deployed incompatible
-  ## versions.
-  if (requirements$timeType != "continuous") {
-    msg <- "Only continuous time models currently supported"
-    return(odin_validate_error_value(msg, integer(0)))
-  }
+  requirements <- validate_requirements(requirements)
 
   dat <- result$result
-
-  if (dat$features$discrete) {
-    ## Once discrete time models are supported at all, we will also need
-    ## to check that stochastic models do not use output (or
-    ## interpolation?) as this is not supported in dust, even though it
-    ## still is in odin itself.
-    msg <- "Expected a continuous time model (using deriv, not update)"
+  is_discrete <- dat$features$discrete
+  model_time_type <- if (is_discrete) "discrete" else "continuous"
+  if (model_time_type != requirements$timeType) {
+    using <- list(continuous = "deriv", discrete = "update")
+    msg <- sprintf("Expected a %s time model (using %s, not %s)",
+                   requirements$timeType,
+                   using[[requirements$timeType]],
+                   using[[model_time_type]])
     vars <- names(dat$data$variable$contents)
     line <- lapply(dat$equations, function(el) {
       if (el$lhs %in% vars && el$name %in% dat$components$rhs)
@@ -86,6 +75,17 @@ check_requirements <- function(result, requirements) {
     })
     return(odin_validate_error_value(msg, line))
   }
+
+  if (is_discrete && dat$features$has_output) {
+    msg <- "output() is not supported in discrete time models"
+    vars <- names(dat$data$output$contents)
+    line <- lapply(dat$equations, function(el) {
+      if (el$lhs %in% vars && el$name %in% dat$components$rhs)
+        el$source else NULL
+    })
+    return(odin_validate_error_value(msg, line))
+  }
+
   if (dat$features$has_array) {
     ## Later, we'll check here to find out where arrays are being used
     ## as there are two separate problems:
@@ -152,4 +152,23 @@ parse_parse_error <- function(msg) {
   }
 
   list(msg = msg, line = line)
+}
+
+
+## this bit validates the request, not the model
+validate_requirements <- function(requirements) {
+  if (is.null(requirements)) {
+    requirements <- list()
+  }
+  ## Default to continuous time:
+  requirements$timeType <- requirements$timeType %||% "continuous"
+
+  time_type_valid <- c("continuous", "discrete")
+  if (!(requirements$timeType %in% time_type_valid)) {
+    porcelain::porcelain_stop(
+      sprintf("Unexpected value '%s' for timeType", requirements$timeType),
+      status_code = 400)
+  }
+
+  requirements
 }

--- a/R/odin.R
+++ b/R/odin.R
@@ -98,10 +98,9 @@ check_requirements <- function(result, requirements) {
 
   if (is_discrete && dat$features$has_output) {
     msg <- "output() is not supported in discrete time models"
-    vars <- names(dat$data$output$contents)
+    output <- names(dat$data$output$contents)
     line <- lapply(dat$equations, function(el) {
-      if (el$lhs %in% vars && el$name %in% dat$components$rhs)
-        el$source else NULL
+      if (el$lhs %in% output) el$source else NULL
     })
     return(odin_validate_error_value(msg, line))
   }

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -35,5 +35,13 @@
         support_runner_ode,
         returning = porcelain::porcelain_returning_json(),
         validate = validate)
+    },
+    "GET /support/runner-discrete" = function(state, validate) {
+      porcelain::porcelain_endpoint$new(
+        "GET",
+        "/support/runner-discrete",
+        support_runner_discrete,
+        returning = porcelain::porcelain_returning_json(),
+        validate = validate)
     })
 }

--- a/R/util.R
+++ b/R/util.R
@@ -41,3 +41,8 @@ read_string <- function(path) {
 system_file <- function(path, package) {
   system.file(path, package = package, mustWork = TRUE)
 }
+
+
+list_to_integer <- function(x) {
+  vapply(x, identity, integer(1))
+}

--- a/R/util.R
+++ b/R/util.R
@@ -28,3 +28,16 @@ prepare_code <- function(code, pretty) {
   }
   code
 }
+
+
+read_string <- function(path) {
+  ## We need 'warn = FALSE' here to prevent warnings about missing
+  ## trailing newlines (which the bundled js files in odin lack due to
+  ## webpack)
+  paste(readLines(path, warn = FALSE), collapse = "\n")
+}
+
+
+system_file <- function(path, package) {
+  system.file(path, package = package, mustWork = TRUE)
+}

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -7,6 +7,10 @@
                 "type": "string"
             }
         },
+        "dt": {
+            "comment": "Time step, for discrete time models (null for continuous time models)",
+            "type": ["null", "number"]
+        },
         "parameters": {
             "type": "array",
             "items": {

--- a/inst/schema/requirements.json
+++ b/inst/schema/requirements.json
@@ -5,7 +5,7 @@
         "timeType": {
             "comment": "The time model used",
             "type": "string",
-            "enum": ["continuous"]
+            "enum": ["continuous", "discrete"]
         }
     }
 }

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -26,9 +26,11 @@ test_that("Validate model", {
   res <- model_validate(json)
   expect_setequal(names(res), c("valid", "metadata"))
   expect_true(res$valid)
-  expect_setequal(names(res$metadata), c("variables", "parameters", "messages"))
+  expect_setequal(names(res$metadata),
+                  c("variables", "parameters", "dt", "messages"))
   expect_equal(res$metadata$variables, "x")
   expect_equal(res$metadata$parameters, list())
+  expect_null(res$metadata$dt)
   expect_equal(res$metadata$messages, list())
 
   endpoint <- odin_api_endpoint("POST", "/validate")
@@ -78,23 +80,6 @@ test_that("Validate rejects invalid model", {
   expect_true(res_endpoint$validated)
   expect_equal(res_endpoint$status_code, 200)
   expect_equal(res_endpoint$data, res)
-})
-
-
-test_that("Validate rejects discrete time model", {
-  data <- list(model = "initial(x) <- 1\nupdate(x) <- 1",
-               requirements = list(timeType = "continuous"))
-  json <- jsonlite::toJSON(data, auto_unbox = TRUE)
-
-  res <- model_validate(json)
-  expect_setequal(names(res), c("valid", "error"))
-  expect_false(res$valid)
-  expect_setequal(names(res$error), c("message", "line"))
-  expect_match(
-    res$error$message,
-    "Expected a continuous time model (using deriv, not update)",
-    fixed = TRUE)
-  expect_equal(res$error$line, 2)
 })
 
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -220,3 +220,16 @@ test_that("Can generate support code", {
   expect_equal(res_endpoint$content_type, "application/json")
   expect_equal(res_endpoint$data, res)
 })
+
+
+test_that("Can generate support code", {
+  res <- support_runner_discrete()
+  expect_true(js::js_validate_script(res))
+
+  endpoint <- odin_api_endpoint("GET", "/support/runner-discrete")
+  res_endpoint <- endpoint$run()
+
+  expect_equal(res_endpoint$status_code, 200)
+  expect_equal(res_endpoint$content_type, "application/json")
+  expect_equal(res_endpoint$data, res)
+})

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -1,7 +1,20 @@
-test_that("can validate simple model", {
+test_that("can validate simple ode model", {
   code <- c("initial(x) <- 1",
             "deriv(x) <- 1")
   res <- odin_js_validate(code, NULL)
+  expect_mapequal(
+    res,
+    list(valid = scalar(TRUE),
+         metadata = list(variables = "x",
+                         parameters = list(),
+                         messages = list())))
+})
+
+
+test_that("can validate simple discrete time model", {
+  code <- c("initial(x) <- 1",
+            "update(x) <- 1")
+  res <- odin_js_validate(code, list(timeType = "discrete"))
   expect_mapequal(
     res,
     list(valid = scalar(TRUE),
@@ -29,6 +42,19 @@ test_that("can ensure models have the expected time type", {
             "update(x) <- 1")
   res <- odin_js_validate(code, list(timeType = "continuous"))
   msg <- "Expected a continuous time model (using deriv, not update)"
+  expect_mapequal(
+    res,
+    list(valid = scalar(FALSE),
+         error = list(
+           message = scalar(msg), line = 2)))
+})
+
+
+test_that("can ensure models have the expected time type", {
+  code <- c("initial(x) <- 1",
+            "deriv(x) <- 1")
+  res <- odin_js_validate(code, list(timeType = "discrete"))
+  msg <- "Expected a discrete time model (using update, not deriv)"
   expect_mapequal(
     res,
     list(valid = scalar(FALSE),

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -106,6 +106,21 @@ test_that("disable use of arrays", {
 })
 
 
+test_that("disable use of output within discrete models", {
+  code <- c("initial(x) <- 1",
+            "update(x) <- 1",
+            "output(a) <- 1",
+            "output(b) <- 2")
+  res <- odin_js_validate(code, list(timeType = "discrete"))
+  msg <-  "output() is not supported in discrete time models"
+  expect_mapequal(
+    res,
+    list(valid = scalar(FALSE),
+         error = list(
+           message = scalar(msg), line = c(3, 4))))
+})
+
+
 test_that("can return nice errors on parse failure", {
   res <- odin_js_validate("y <- 1\nz <- 2\nx b\na <- 1", NULL)
   expect_equal(res$valid, scalar(FALSE))


### PR DESCRIPTION
This PR adds support for validating and compiling discrete time models into odin.api; it should be safe to deploy before the frontend supports discrete models, as nothing has changed in the treatment of continuous time models, and discrete time models require the additional body parameter `timeType` to be `"discrete"`

Things in here:

* we check the `timeType` agrees with what the app requests. Invalid values throw a 400 error, and should not happen in reality
* discrete time models forbid use of `output()` so we add a check for this
* we add unconditionally a `dt` element to the returned metadata, which we'll use for time scaling (see the [dust js docs](https://mrc-ide.github.io/dust-js/functions/wodinRunDiscrete.html). The code for extracting the dt value from a model is fairly nasty, but will want future extension, not needed for this year's course though.
* there's a new endpoint for downloading the support code for running the discrete time models (i.e., dust.js)