### PR TITLE
Don't return NULL line numbers on error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.api
 Title: Serve 'odin' Models via an API
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/odin.R
+++ b/R/odin.R
@@ -50,7 +50,8 @@ odin_js_validate <- function(code, requirements) {
       if (eq$type != "expression_scalar" || !is.numeric(eq$rhs$value)) {
         msg <- "'dt' must be a simple numeric expression, if present"
         return(list(valid = scalar(FALSE),
-                    error = odin_error_detail(msg, list_to_integer(eq$source))))
+                    error = odin_error_detail(msg,
+                                              list_to_integer(eq$source))))
       }
       dt <- scalar(eval(eq$rhs$value, baseenv()))
     }
@@ -136,7 +137,7 @@ odin_validate_error_value <- function(msg, line = integer(0)) {
 
 odin_error_detail <- function(msg, line) {
   list(message = scalar(msg),
-       line = line)
+       line = line %||% integer(0))
 }
 
 

--- a/tests/testthat/test-odin.R
+++ b/tests/testthat/test-odin.R
@@ -145,3 +145,13 @@ test_that("can tidy up parse errors", {
                list(msg = "unexpected symbol",
                     line = 1))
 })
+
+
+test_that("don't return NULL for lines even when lines not known", {
+  res <- odin_js_validate("initial(x) <- 1")
+  expect_equal(res$valid, scalar(FALSE))
+  expect_equal(
+    res$error,
+    list(message = scalar("Did not find a deriv() or an update() call"),
+         line = integer(0)))
+})


### PR DESCRIPTION
Now always return an empty array, not sure if that will be better in the api, but it *is* what the spec says...

See https://github.com/mrc-ide/wodin/pull/113, in particular:

> Finally, I put in the fix for the error allert caused by the invalid stochastic code, which was that getCodeErrorFromResponse was assuming that the line prop in OdinModelResponseError would never be null, but it is in this case.