### PR TITLE
Cope with models that include fractional user

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.api
 Title: Serve 'odin' Models via an API
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/odin.R
+++ b/R/odin.R
@@ -59,8 +59,12 @@ odin_js_validate <- function(code, requirements) {
 
   process_user <- function(nm) {
     x <- dat$equations[[nm]]$user
+    default <- x$default %||% NA_real_
+    if (is.recursive(default)) {
+      default <- eval(list_to_sexp(default), baseenv())
+    }
     list(name = scalar(nm),
-         default = scalar(x$default %||% NA),
+         default = scalar(default),
          min = scalar(x$min %||% NA),
          max = scalar(x$max %||% NA),
          is_integer = scalar(x$integer %||% FALSE),

--- a/R/util.R
+++ b/R/util.R
@@ -46,3 +46,14 @@ system_file <- function(path, package) {
 list_to_integer <- function(x) {
   vapply(x, identity, integer(1))
 }
+
+
+list_to_sexp <- function(x) {
+  if (is.recursive(x)) {
+    as.call(lapply(x, list_to_sexp))
+  } else if (is.character(x)) {
+    as.name(x)
+  } else {
+    x
+  }
+}

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -243,3 +243,15 @@ test_that("Can generate support code", {
   expect_equal(res_endpoint$content_type, "application/json")
   expect_equal(res_endpoint$data, res)
 })
+
+
+test_that("don't fail if user calls have fractions", {
+  data <- list(model = c("initial(x) <- 1",
+                         "deriv(x) <- a",
+                         "a <- user(1 / 2)"))
+  json <- jsonlite::toJSON(data, auto_unbox = TRUE)
+  res <- model_validate(json)
+  expect_equal(
+    res$metadata$parameters[[1]]$default,
+    scalar(0.5))
+})


### PR DESCRIPTION
Deployed to wodin-dev, no longer showing the error.

The issue was we were failing to return the expected type (a number) back where odin was giving us back an s expression, so I've evaluated that into a number here.